### PR TITLE
Adjust size of logo font to account for whitespace around app

### DIFF
--- a/src/components/Logo/Logo.css
+++ b/src/components/Logo/Logo.css
@@ -1,7 +1,7 @@
 .logo {
   color: #daa520;
   font-family: Megrim;
-  font-size: 72px;
+  font-size: 65px;
   font-weight: 500;
   margin-top: 0;
   padding-top: 20px;


### PR DESCRIPTION
## Description: Adjusted Logo font size

This PR addresses issue #`54`.

The changes made to the codebase in this PR:

- lowered logo font size to account for white space around app

## Testing

no tests written