### PR TITLE
add tests and for postAffirmations async call and refactor tests

### DIFF
--- a/src/helper/postAffirmation.js
+++ b/src/helper/postAffirmation.js
@@ -1,0 +1,21 @@
+export const postAffirmation = async (url, affirmation_text) => {
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        affirmation: { affirmation_text }
+      })
+    });
+    if (!response.ok) {
+      throw Error(response.statusText);
+    }
+
+    const statusCode = await response.json();
+    return statusCode;
+  } catch (error) {
+    return error.message;
+  }
+};

--- a/src/helper/postAffirmation.test.js
+++ b/src/helper/postAffirmation.test.js
@@ -1,0 +1,52 @@
+import { postAffirmation } from './postAffirmation';
+
+describe('postAffirmation', () => {
+  let mockUrl;
+  let mockAffirmationText;
+  beforeEach(() => {
+    mockUrl = 'www.journals.com';
+    mockAffirmationText = 'I am worthy of love and happiness.';
+  });
+
+  it('should call fetch with the correct params', () => {
+    window.fetch = jest.fn();
+
+    const expectedBody = {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        affirmation: { affirmation_text: mockAffirmationText }
+      })
+    };
+
+    postAffirmation(mockUrl, mockAffirmationText);
+    expect(window.fetch).toHaveBeenCalledWith(mockUrl, expectedBody);
+  });
+
+  it('should return an error message is response is not ok', async () => {
+    window.fetch = jest.fn().mockImplementation(() => {
+      return Promise.resolve({
+        ok: false,
+        statusText: 'an error has occurred'
+      });
+    });
+
+    const result = await postAffirmation(mockUrl, mockAffirmationText);
+    expect(result).toEqual('an error has occurred');
+  });
+
+  it('should return a status code if response is ok', async () => {
+    window.fetch = jest.fn().mockImplementation(() => {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ statusCode: 200 })
+      });
+    });
+
+    const result = await postAffirmation(mockUrl, mockAffirmationText);
+
+    expect(result).toEqual({ statusCode: 200 });
+  });
+});

--- a/src/reducers/journalReducer.test.js
+++ b/src/reducers/journalReducer.test.js
@@ -18,7 +18,7 @@ describe('journalReducer', () => {
       {},
       {
         type: 'SAVE_JOURNAL_ENTRY',
-        journal: {
+        journal_entry: {
           attributes: {
             entry_text: 'Hello world'
           }

--- a/src/thunks/__tests__/getJournalEntry.js
+++ b/src/thunks/__tests__/getJournalEntry.js
@@ -10,22 +10,18 @@ describe('getJournalEntry', () => {
     mockUrl = 'www.journals.com';
     mockDispatch = jest.fn();
     mockJournalEntry = {
-      journal: {
-        id: '10',
-        type: 'journal_entry',
-        attributes: {
-          created_at: '2019-02-19T00:00:00.000Z',
-          entry_text: 'I am upset today. I slipped on ice and my back hurts.',
-          tones: {
-            id: 9,
-            primary_tone: 'sadness',
-            secondary_tone: 'analytical',
-            journal_entry_id: 10,
-            created_at: '2019-02-19T00:40:00.018Z',
-            updated_at: '2019-02-19T00:51:18.180Z',
-            primary_score: '0.796933',
-            secondary_score: '0.824412'
-          }
+      attributes: {
+        created_at: '2019-02-19T00:00:00.000Z',
+        entry_text: 'I am upset today. I slipped on ice and my back hurts.',
+        tones: {
+          id: 9,
+          primary_tone: 'sadness',
+          secondary_tone: 'analytical',
+          journal_entry_id: 10,
+          created_at: '2019-02-19T00:40:00.018Z',
+          updated_at: '2019-02-19T00:51:18.180Z',
+          primary_score: '0.796933',
+          secondary_score: '0.824412'
         }
       }
     };
@@ -67,7 +63,7 @@ describe('getJournalEntry', () => {
     await thunk(mockDispatch);
 
     expect(mockDispatch).toHaveBeenCalledWith(
-      Actions.saveJournalEntry(mockJournalEntry)
+      Actions.saveJournalEntry(mockJournalEntry.attributes)
     );
   });
 });

--- a/src/thunks/__tests__/patchJournalEntry.js
+++ b/src/thunks/__tests__/patchJournalEntry.js
@@ -49,14 +49,17 @@ describe('patchJournalEntry', () => {
     window.fetch = jest.fn().mockImplementation(() => {
       return Promise.resolve({
         ok: true,
-        json: () => Promise.resolve({ data: mockEntryText })
+        json: () =>
+          Promise.resolve({
+            data: { attributes: { entry_text: mockEntryText } }
+          })
       });
     });
 
     const thunk = patchJournalEntry(mockUrl, mockEntryText);
     await thunk(mockDispatch);
     expect(mockDispatch).toHaveBeenCalledWith(
-      Actions.saveJournalEntry({ data: 'I am happy.' })
+      Actions.saveJournalEntry({ entry_text: 'I am happy.' })
     );
   });
 });


### PR DESCRIPTION
## Description:

This PR addresses issue #`34`.

The changes made to the codebase in this PR:

- Added async functionality and tests for postAffirmation. 
- Refactor async tests to pass with correct data. 

## Testing

These changes affect the following tests:

-getJournalEntry
-saveJournalEntry

All async tests are now passing with 100% test coverage. 
