### PR TITLE
Fix Github links for core contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Planned enhancements include:
 
 ## 🚀 Core Contributors
 **Ashton Bailey**
-Github:[https://github.com/amypetrie/](https://github.com/ashtonkbailey/)
+Github:[https://github.com/ashtonkbailey/](https://github.com/ashtonkbailey/)
 
 **Tanjie Mcmeans**
-Github:[https://github.com/normanrs](https://github.com/TMcMeans/)
+Github:[https://github.com/TMcMeans](https://github.com/TMcMeans/)


### PR DESCRIPTION
Edited github links to point to correct profiles in ReadMe - no other changes to codebase. 